### PR TITLE
poc: ingestion reader update

### DIFF
--- a/bin/ingestion.js
+++ b/bin/ingestion.js
@@ -1,39 +1,42 @@
 const async = require('async');
 const schedule = require('node-schedule');
+const zookeeper = require('node-zookeeper-client');
 
 const werelogs = require('werelogs');
+const { HealthProbeServer } = require('arsenal').network.probe;
 
+const IngestionPopulator = require('../lib/queuePopulator/IngestionPopulator');
 const config = require('../conf/Config');
+
 const zkConfig = config.zookeeper;
 const kafkaConfig = config.kafka;
-const extConfigs = config.extensions;
+const ingestionExtConfigs = config.extensions.ingestion;
 const qpConfig = config.queuePopulator;
 const mConfig = config.metrics;
 const rConfig = config.redis;
 const s3Config = config.s3;
-const IngestionPopulator = require('../lib/queuePopulator/IngestionPopulator');
-const zookeeper = require('node-zookeeper-client');
 
-const { HealthProbeServer } = require('arsenal').network.probe;
 const log = new werelogs.Logger('Backbeat:IngestionPopulator');
-
 werelogs.configure({ level: config.log.logLevel,
     dump: config.log.dumpLevel });
 
+// TODO: based on source list config changes, dynamically add/remove
+const activeIngestionSources = [];
+
 /* eslint-disable no-param-reassign */
-function queueBatch(queuePopulator, taskState, qConfig, log) {
+function queueBatch(ingestionPopulator, taskState, qConfig, log) {
     if (taskState.batchInProgress) {
-        log.warn('skipping replication batch: previous one still in progress');
+        log.warn('skipping ingestion batch: previous one still in progress');
         return undefined;
     }
-    log.debug('start queueing replication batch');
+    log.debug('start queueing ingestion batch');
     taskState.batchInProgress = true;
     const maxRead = qpConfig.batchMaxRead;
-    queuePopulator.processLogEntries({ maxRead }, err => {
+    ingestionPopulator.processLogEntries({ maxRead }, err => {
         taskState.batchInProgress = false;
         if (err) {
-            log.error('an error occurred during replication', {
-                method: 'QueuePopulator::task.queueBatch',
+            log.error('an error occurred during ingestion', {
+                method: 'IngestionPopulator::task.queueBatch',
                 error: err,
             });
         }
@@ -42,18 +45,42 @@ function queueBatch(queuePopulator, taskState, qConfig, log) {
 }
 /* eslint-enable no-param-reassign */
 
+function initIngestionReaders(ingestionPopulator, cb) {
+    // TODO: use config level updated sources list. for now stick with static
+    const ingestionSources = ingestionExtConfigs.sources;
+
+    return async.each(ingestionSources, (source, next) => {
+        ingestionPopulator.addNewLogSource(source, err => {
+            if (err) {
+                log.error('error adding ingestion source', {
+                    source: source.name,
+                    prefix: source.prefix,
+                    type: source.type,
+                    method: 'IngestionPopulator::task',
+                });
+                return next(err);
+            }
+            // TODO: config change. Should somehow depend on:
+            //       Storage Location Name + Local Zenko Bucket Name
+            const key = `${source.prefix}:${source.name}`;
+            activeIngestionSources.push(key);
+            return next();
+        });
+    }, cb);
+}
+
 const ingestionPopulator = new IngestionPopulator(zkConfig, kafkaConfig,
-    qpConfig, mConfig,
-    rConfig, extConfigs, s3Config);
+    qpConfig, mConfig, rConfig, ingestionExtConfigs, s3Config);
 
 const healthServer = new HealthProbeServer({
     bindAddress: config.healthcheckServer.bindAddress,
     port: config.healthcheckServer.port,
 });
 
-
 async.waterfall([
     done => ingestionPopulator.open(done),
+    // on init, setup active sources ingestion readers
+    done => initIngestionReaders(ingestionPopulator, done),
     done => {
         const taskState = {
             batchInProgress: false,
@@ -78,12 +105,14 @@ async.waterfall([
     },
 ], err => {
     if (err) {
-        log.error('error during queue populator initialization', {
-            method: 'QueuePopulator::task',
+        log.error('error during ingestion populator initialization', {
+            method: 'IngestionPopulator::task',
             error: err,
         });
         process.exit(1);
     }
+
+    // TODO: dynamic add/remove checks here
 });
 
 process.on('SIGTERM', () => {

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -5,18 +5,13 @@ const Logger = require('werelogs').Logger;
 const zookeeper = require('../clients/zookeeper');
 const ProvisionDispatcher = require('../provisioning/ProvisionDispatcher');
 const IngestionReader = require('./IngestionReader');
-const BucketFileLogReader = require('./BucketFileLogReader');
 const MetricsProducer = require('../MetricsProducer');
 const MetricsConsumer = require('../MetricsConsumer');
-const FailedCRRConsumer =
-    require('../../extensions/replication/failedCRR/FailedCRRConsumer');
 const MongoLogReader = require('./MongoLogReader');
-const IngestionQueuePopulator =
-    require('../../extensions/ingestion/IngestionQueuePopulator');
 
 class IngestionPopulator {
     /**
-     * Create a queue populator object to populate various kafka
+     * Create a ingestion populator object to populate various kafka
      * queues from the metadata log
      *
      * @constructor
@@ -40,21 +35,20 @@ class IngestionPopulator {
      * @param {Object} mConfig - metrics configuration object
      * @param {string} mConfig.topic - metrics topic
      * @param {Object} rConfig - redis configuration object
-     * @param {Object} extConfigs - configuration of extensions: keys
-     *   are extension names and values are extension's config object.
+     * @param {Object} ingestionConfig - ingestion extension configurations
      * @param {Object} s3Config - configuration to connect to S3 Client
      */
     constructor(zkConfig, kafkaConfig, qpConfig, mConfig, rConfig,
-                extConfigs, s3Config) {
+                ingestionConfig, s3Config) {
         this.zkConfig = zkConfig;
         this.kafkaConfig = kafkaConfig;
         this.qpConfig = qpConfig;
         this.mConfig = mConfig;
         this.rConfig = rConfig;
-        this.extConfigs = extConfigs;
+        this.ingestionConfig = ingestionConfig;
         this.s3Config = s3Config;
 
-        this.log = new Logger('Backbeat:QueuePopulator');
+        this.log = new Logger('Backbeat:IngestionPopulator');
 
         // list of active log readers
         this.logReaders = [];
@@ -64,48 +58,45 @@ class IngestionPopulator {
         // metrics clients
         this._mProducer = null;
         this._mConsumer = null;
+
+        // list of provisioned ingestion log sources
+        // i.e.: { raftIdDispatcher1: new ProvisionDispatcher() }
+        this._provisionedIngestionSources = {};
     }
 
     /**
-     * Open the queue populator
+     * Open the ingestion populator
      *
      * @param {function} cb - callback function
      * @return {undefined}
      */
     open(cb) {
-        this._loadExtensions();
+        this._loadExtension();
         async.series([
             next => this._setupMetricsClients(err => {
                 if (err) {
                     this.log.error('error setting up metrics client', {
-                        method: 'QueuePopulator.open',
+                        method: 'IngestionPopulator.open',
                         error: err,
                     });
                 }
                 return next(err);
             }),
-            next => this._setupFailedCRRClients(next),
-            next => this._setupExtensions(err => {
+            next => this._setupIngestionExtension(err => {
                 if (err) {
                     this.log.error(
-                        'error setting up queue populator extensions', {
-                            method: 'QueuePopulator.open',
+                        'error setting up ingestion extension', {
+                            method: 'IngestionPopulator.open',
                             error: err,
                         });
                 }
                 return next(err);
             }),
-            next => this._setupZookeeper(err => {
-                if (err) {
-                    return next(err);
-                }
-                this._setupLogSources();
-                return next();
-            }),
+            next => this._setupZookeeper(next),
         ], err => {
             if (err) {
-                this.log.error('error starting up queue populator',
-                    { method: 'QueuePopulator.open',
+                this.log.error('error starting up ingestion populator',
+                    { method: 'IngestionPopulator.open',
                         error: err });
                 return cb(err);
             }
@@ -125,100 +116,58 @@ class IngestionPopulator {
     }
 
     /**
-     * Set up and start the consumer for retrying failed CRR operations.
-     * @param {Function} cb - The callback function
-     * @return {undefined}
-     */
-    _setupFailedCRRClients(cb) {
-        this._failedCRRConsumer = new FailedCRRConsumer(this.kafkaConfig);
-        return this._failedCRRConsumer.start(cb);
-    }
-
-    /**
-     * Close the queue populator
+     * Close all provisioned ingestion sources
      * @param {function} cb - callback function
      * @return {undefined}
      */
     close(cb) {
-        return this._closeLogState(cb);
+        return async.each(
+            Object.keys(this._provisionedIngestionSources),
+            (raftIdDispatcher, done) => {
+                this.closeLogState(raftIdDispatcher, done);
+            }, cb);
     }
 
-    _setupLogSources() {
-        switch (this.qpConfig.logSource) {
-        case 'bucketd':
-            // initialization of log source is deferred until the
-            // dispatcher notifies us of which raft sessions we're
-            // responsible for
-            this._subscribeToLogSourceDispatcher('raft-id-dispatcher');
-            break;
-        case 'mongo':
-            if (this.qpConfig.subscribeToLogSourceDispatcher) {
-                // initialization of mongo log source is deferred until
-                // the dispatcher notifies us we're the single populator
-                // responsible for it
-                this._subscribeToLogSourceDispatcher('mongo-dispatcher');
-            } else {
-                // always consume from mongo log (good for Kubernetes
-                // deployments)
-                this.logReadersUpdate = [
-                    new MongoLogReader({
-                        zkClient: this.zkClient,
-                        kafkaConfig: this.kafkaConfig,
-                        zkConfig: this.zkConfig,
-                        mongoConfig: this.qpConfig.mongo,
-                        logger: this.log,
-                        extensions: this._extensions,
-                        metricsProducer: this._mProducer,
-                    }),
-                ];
+    // dynamically add new log sources
+    addNewLogSource(newSource, cb) {
+        this._extension.createZkPath(err => {
+            if (err) {
+                return cb(err);
             }
-            break;
-        case 'dmd':
-            this.logReadersUpdate = [
-                new BucketFileLogReader({ zkClient: this.zkClient,
-                    kafkaConfig: this.kafkaConfig,
-                    dmdConfig: this.qpConfig.dmd,
-                    logger: this.log,
-                    extensions: this._extensions,
-                    metricsProducer: this._mProducer,
-                }),
-            ];
-            break;
-        default:
-            throw new Error("bad 'logSource' config value: expect 'bucketd,'" +
-                        ` mongo or 'dmd', got '${this.qpConfig.logSource}'`);
-        }
-        if (this.extConfigs.ingestion) {
-            this.extConfigs.ingestion.sources.map(sourceObj => {
-                const zookeeperUrlIngest =
-                    `${this.zkConfig.connectionString}` +
-                    `${this.extConfigs.ingestion.zookeeperPath}/` +
-                    `${sourceObj.name}`;
-                const zkEndpointIngest =
-                    `${zookeeperUrlIngest}/raft-id-dispatcher`;
-                this._subscribeToLogSourceDispatcher(zkEndpointIngest,
-                    sourceObj, this.extConfigs.ingestion.zookeeperPath);
-                return undefined;
-            });
-        }
+            const zookeeperUrlIngest =
+                `${this.zkConfig.connectionString}` +
+                `${this.ingestionConfig.zookeeperPath}/` +
+                `${newSource.name}`;
+            const zkEndpointIngest = `${zookeeperUrlIngest}/raft-id-dispatcher`;
+            return this._subscribeToLogSourceDispatcher(zkEndpointIngest,
+                newSource, cb);
+        }, newSource);
     }
 
-    _subscribeToLogSourceDispatcher(zkEndpoint, bucketd, ingestionPath) {
-        this.raftIdDispatcher =
+    _subscribeToLogSourceDispatcher(zkEndpoint, bucketd, cb) {
+        const ingestionPath = this.ingestionConfig.zookeeperPath;
+        // TODO: What are we replacing ProvisionDispatcher with?
+        const raftIdDispatcher =
             new ProvisionDispatcher({ connectionString: zkEndpoint });
-        this.raftIdDispatcher.subscribe((err, items) => {
+        raftIdDispatcher.subscribe((err, items) => {
             if (err) {
                 this.log.error(
                     'error when receiving log source provision list',
                     { zkEndpoint, error: err });
-                return undefined;
+                return cb(err);
             }
+            // TODO: config change. Should somehow depend on:
+            //       Storage Location Name + Local Zenko Bucket Name
+            const key = `${bucketd.prefix}:${bucketd.name}`;
+            this._provisionedIngestionSources[key] = raftIdDispatcher;
+
             if (items.length === 0) {
                 this.log.info('no log source provisioned, idling',
                               { zkEndpoint });
             }
             const newRaftReaders = items.map(
                 token => {
+                    // TODO: will token ever be mongo?
                     if (token === 'mongo') {
                         return new MongoLogReader({
                             zkClient: this.zkClient,
@@ -226,7 +175,7 @@ class IngestionPopulator {
                             zkConfig: this.zkConfig,
                             mongoConfig: this.qpConfig.mongo,
                             logger: this.log,
-                            extensions: this._extensions,
+                            extensions: [this._extension],
                             metricsProducer: this._mProducer,
                         });
                     }
@@ -236,16 +185,15 @@ class IngestionPopulator {
                         bucketdConfig: bucketd,
                         raftId: token,
                         logger: this.log,
-                        extensions: this._extensions,
+                        extensions: [this._extension],
                         metricsProducer: this._mProducer,
                         ingestionPath,
                         qpConfig: this.qpConfig,
                         s3Config: this.s3Config,
                     });
                 });
-            newRaftReaders.forEach(reader =>
-                this.logReadersUpdate.push(reader));
-            return undefined;
+            this.logReadersUpdate.push(...newRaftReaders);
+            return cb();
         });
         this.log.info('waiting to be provisioned a log source',
                       { zkEndpoint });
@@ -268,60 +216,65 @@ class IngestionPopulator {
         });
     }
 
-    _loadExtensions() {
-        this._extensions = [];
-        Object.keys(this.extConfigs).forEach(extName => {
-            const extConfig = this.extConfigs[extName];
-            const index = require(`../../extensions/${extName}/index.js`);
-            if (index.queuePopulatorExtension) {
-                // eslint-disable-next-line new-cap
-                const ext = new index.queuePopulatorExtension({
-                    config: extConfig,
-                    logger: this.log,
-                });
-                ext.setZkConfig(this.zkConfig);
-                this.log.info(`${index.name} extension is active`);
-                this._extensions.push(ext);
-            }
+    _loadExtension() {
+        const index = require('../../extensions/ingestion/index.js');
+        if (!index.queuePopulatorExtension) {
+            this.log.fatal('Missing ingestion populator extension file');
+            process.exit(1);
+        }
+        // eslint-disable-next-line new-cap
+        const ext = new index.queuePopulatorExtension({
+            config: this.ingestionConfig,
+            logger: this.log,
         });
+        ext.setZkConfig(this.zkConfig);
+        this._extension = ext;
+
+        this.log.info('ingestion extension is active');
     }
 
-    _setupExtensions(cb) {
-        return async.each(this._extensions, (ext, next) => {
-            ext.setupZookeeper(err => {
-                if (err) {
-                    return next(err);
-                }
-                if (ext.createZkPath) {
-                    if (ext instanceof IngestionQueuePopulator) {
-                        return async.each(
-                            this.extConfigs.ingestion.sources,
-                            (source, next) => ext.createZkPath(next, source),
-                            next);
-                    }
-                    return ext.createZkPath(next);
-                }
-                return next();
-            });
-        }, cb);
+    _setupIngestionExtension(cb) {
+        // single extension, init sources by calling 'addNewLogSource'
+        return this._extension.setupZookeeper(cb);
     }
 
+    // I changed to push instead here, and will remove logReaders from the
+    // existing `this.logReaders` array whenever removing a log source. To do
+    // this, I need to save an additional property on IngestionReader to find
+    // correct source to remove
     _setupUpdatedReaders(done) {
         const newReaders = this.logReadersUpdate;
+        // TODO: may require some sort of locking here
         this.logReadersUpdate = [];
         async.each(newReaders, (logReader, cb) => logReader.setup(cb),
                    err => {
                        if (err) {
                            return done(err);
                        }
-                       this.logReaders = newReaders;
+                       this.logReaders.push(...newReaders);
                        return done();
                    });
     }
 
-    _closeLogState(done) {
-        if (this.raftIdDispatcher !== undefined) {
-            return this.raftIdDispatcher.unsubscribe(done);
+    // Can be used to dynamically remove sources
+    // TODO-FIX: sourceName === `${prefix}:${name}`
+    closeLogState(sourceName, done) {
+        const raftIdDispatcher = this._provisionedIngestionSources[sourceName];
+        if (raftIdDispatcher !== undefined) {
+            delete this._provisionedIngestionSources[sourceName];
+            // Also need to remove from `this.loadReaders`
+            // May also need to check `this.logReadersUpdate`
+            let index = this.logReaders.findIndex(lr =>
+                lr.getSourceIDName() === sourceName);
+            if (index !== -1) {
+                this.logReaders.splice(index, 1);
+            }
+            index = this.logReadersUpdate.findIndex(lr =>
+                lr.getSourceIDName() === sourceName);
+            if (index !== -1) {
+                this.logReadersUpdate.splice(index, 1);
+            }
+            return raftIdDispatcher.unsubscribe(done);
         }
         return process.nextTick(done);
     }

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -39,6 +39,7 @@ class IngestionReader extends LogReader {
     /* eslint-disable no-param-reassign */
 
     _processReadRecords(params, batchState, done) {
+        const { logger } = batchState;
         const readOptions = {};
         if (this.logOffset !== undefined) {
             readOptions.startSeq = this.logOffset;
@@ -46,7 +47,7 @@ class IngestionReader extends LogReader {
         if (params && params.maxRead !== undefined) {
             readOptions.limit = params.maxRead;
         }
-        this.log.debug('reading records', { readOptions });
+        logger.debug('reading records', { readOptions });
         return async.waterfall([
             next => this._readLogOffset((err, res) => {
                 const offset = Number.parseInt(res, 10);
@@ -64,7 +65,7 @@ class IngestionReader extends LogReader {
                 }
                 return this._iProducer.snapshot(this.raftId, (err, res) => {
                     if (err) {
-                        this.log.error('error generating snapshot for ' +
+                        logger.error('error generating snapshot for ' +
                         'ingestion', { err });
                         return next(err);
                     }
@@ -115,7 +116,7 @@ class IngestionReader extends LogReader {
     }
 
     _processPrepareEntries(batchState, done) {
-        const { entriesToPublish, logRes, logStats } = batchState;
+        const { entriesToPublish, logRes, logStats, logger } = batchState;
 
         this._setEntryBatch(entriesToPublish);
 
@@ -141,20 +142,20 @@ class IngestionReader extends LogReader {
             });
         });
         logRes.log.on('error', err => {
-            this.log.error('error fetching entries from log',
+            logger.error('error fetching entries from log',
                 { method: 'LogReader._processPrepareEntries',
                     error: err });
             return done(err);
         });
         logRes.log.on('end', () => {
-            this.log.debug('ending record stream');
+            logger.debug('ending record stream');
             return done();
         });
         return undefined;
     }
 
     _processPublishEntries(batchState, done) {
-        const { entriesToPublish, logRes, logStats } = batchState;
+        const { entriesToPublish, logRes, logStats, logger } = batchState;
 
         if (this.remoteLogOffset /* &&
         config.queuePopulator.logSource.indexOf('ingestion') > -1 */) {
@@ -175,7 +176,7 @@ class IngestionReader extends LogReader {
                 done => this._producers[topic].send(topicEntries, done),
             ], err => {
                 if (err) {
-                    this.log.error(
+                    logger.error(
                         'error publishing entries from log to topic',
                         { method: 'LogReader._processPublishEntries',
                           topic,
@@ -183,18 +184,13 @@ class IngestionReader extends LogReader {
                           error: err });
                     return done(err);
                 }
-                this.log.debug('entries published successfully to topic',
+                logger.debug('entries published successfully to topic',
                                { method: 'LogReader._processPublishEntries',
                                  topic, entryCount: topicEntries.length });
                 batchState.publishedEntries[topic] = topicEntries;
                 return done();
             });
-        }, err => {
-            if (err) {
-                return done(err);
-            }
-            return done();
-        });
+        }, done);
     }
 
     _processSaveLogOffset(batchState, done) {
@@ -209,8 +205,6 @@ class IngestionReader extends LogReader {
         }
         return process.nextTick(() => done());
     }
-
-    /* eslint-enable no-param-reassign */
 
     getLogInfo() {
         return { raftId: this.raftId };

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -27,11 +27,13 @@ class IngestionReader extends LogReader {
             bucketdConfig.name;
         this.newIngestion = false;
         this.remoteLogOffset = null;
-        if (ingestionPath) {
-            this.pathToLogOffset = `${ingestionPath}` +
-                `${bucketdConfig.zookeeperSuffix}` +
-                `/logState/raft_${raftId}/logOffset`;
-        }
+        this.pathToLogOffset = `${ingestionPath}` +
+            `${bucketdConfig.zookeeperSuffix}` +
+            `/logState/raft_${raftId}/logOffset`;
+
+        // TODO: config change
+        // identifier
+        this._sourceIDName = `${bucketdConfig.prefix}:${bucketdConfig.name}`;
     }
 
     /* eslint-disable no-param-reassign */
@@ -212,6 +214,10 @@ class IngestionReader extends LogReader {
 
     getLogInfo() {
         return { raftId: this.raftId };
+    }
+
+    getSourceIDName() {
+        return this._sourceIDName;
     }
 }
 

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -238,6 +238,13 @@ class QueuePopulator {
     _loadExtensions() {
         this._extensions = [];
         Object.keys(this.extConfigs).forEach(extName => {
+            if (extName === 'ingestion') {
+                // skip ingestion extension in regular QueuePopulator
+                // TODO: We can probably combine QueuePopulator &
+                //       IngestionPopulator but will add extra complexity to
+                //       QueuePopulator
+                return;
+            }
             const extConfig = this.extConfigs[extName];
             const index = require(`../../extensions/${extName}/index.js`);
             if (index.queuePopulatorExtension) {


### PR DESCRIPTION
EDIT:
This poc will change as the init process will be the primary mongo reader to read/filter bucket entries. Identifying a bucket entry will lead to adding a new IngestionReader as we have identified a new ingestion source.
A new IngestionReader means we need to know transport, host, and port. We need to get this from mongo metadata directly rather than relying on configs.

Things to consider on init:
- Start mongo reader for finding new ingestion buckets
- Check zookeeper for previous sources we've setup (and setup these IngestionReader's)
- We can reduce zookeeper reads by memoizing/caching statuses in memory. Only on init, will we ever read from zookeeper. On successful writes, we can save directly in memory and avoid an extra read.

---

Example add/remove ingestion readers in the `IngestionPopulator` class

Currently, I'm using the static source list defined in the config file, but the add/remove methods are available to eventually dynamically update log readers

General idea is to separate out and only initialize ingestion using the entry point `bin/ingestion.js`.
This means on init, we only use the ingestion extension (and ignore the ingestion extension on entry `bin/queuePopulator.js`.

- Use `IngestionPopulator.addNewLogSource` to populate ingestion log readers
- Use `IngestionPopulator.closeLogState` to remove ingestion log readers and close them
- Use `this._provisionedIngestionSources` instance variable to keep track of provisioned log sources so we can properly close them when needed.
- In `bin/ingestion.js`, use var `activeIngestionSources` to also keep track of active ingestion sources that we already provisioned.


I think necessary todos include config changes. I think we need location storage name and the local zenko bucket name to avoid conflicts in keeping track of log sources.

Edit:
Rahul: Is it ok to use workflows?
Jay and I are building on the idea that we will use workflows.
User will create Storage Location, then go to Ingestion workflow tab, select storage location, input a bucket name (to represent local zenko bucket name), and on successful setup (i.e. bucket name wasn't already taken), a new ingestion workflow is added.